### PR TITLE
Solve TypeError

### DIFF
--- a/src/binidx.py
+++ b/src/binidx.py
@@ -189,8 +189,8 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
     def __getstate__(self):
         return self._path
 
-    def __setstate__(self, state):
-        self._do_init(state)
+    def __setstate__(self, state, skip_warmup=False):
+        self._do_init(state, skip_warmup)
 
     def _do_init(self, path, skip_warmup):
         self._path = path


### PR DESCRIPTION
When starting training, the model will report an TypeError error: MMapIndexedDataset._do_init() missing 1 required positional argument: 'skip_warmup', it was found that "skip_warmup" parameter was not passed in when __setstate__ called self._do_init(). This commit fixes this problem.