### PR TITLE
[Bugfix] Solve the rwkv7 dim_ffn size problem

### DIFF
--- a/demo-training-prepare-v7-pile.sh
+++ b/demo-training-prepare-v7-pile.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#######################################################################################################################
+################################################################################
 #
 # This will generate the initial model, and save it to the output folder
 #
@@ -7,7 +7,7 @@
 # pile_20B_tokenizer_text_document.bin (664230651068 bytes)
 # pile_20B_tokenizer_text_document.idx (4212099722 bytes)
 #
-#######################################################################################################################
+################################################################################
 #
 MODEL_TYPE="x070" # x070 => rwkv-7.0
 #
@@ -17,7 +17,7 @@ N_EMBD="768"
 CTX_LEN="4096" # !!! change magic_prime if you change ctx_len !!!
 PROJ_DIR="out/L"$N_LAYER"-D"$N_EMBD"-"$MODEL_TYPE # set output folder
 #
-#######################################################################################################################
+################################################################################
 #
 python train.py --wandb "" --proj_dir $PROJ_DIR \
  --data_file "/mnt/nvme0n1/pile/pile_20B_tokenizer_text_document" --data_type "binidx" --vocab_size 50304 --my_testing $MODEL_TYPE \

--- a/demo-training-prepare.sh
+++ b/demo-training-prepare.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-#######################################################################################################################
+################################################################################
 #
 # This will generate the initial model, and save it to the output folder
 #
-#######################################################################################################################
+################################################################################
 #
 # Please firstly create data folder & Download minipile (1498226207 tokens, around 3GB)
 # mkdir -p data
 # wget --continue -O data/minipile.idx https://huggingface.co/datasets/BlinkDL/minipile-tokenized/resolve/main/rwkv_vocab_v20230424/minipile.idx
 # wget --continue -O data/minipile.bin https://huggingface.co/datasets/BlinkDL/minipile-tokenized/resolve/main/rwkv_vocab_v20230424/minipile.bin
 #
-#######################################################################################################################
+################################################################################
 #
 MODEL_TYPE="x070" # x060 => rwkv-6.0
 #
@@ -20,7 +20,7 @@ N_EMBD="768"
 CTX_LEN="512" # !!! change magic_prime if you change ctx_len !!!
 PROJ_DIR="out/L"$N_LAYER"-D"$N_EMBD"-"$MODEL_TYPE # set output folder
 #
-#######################################################################################################################
+################################################################################
 #
 # magic_prime = the largest 3n+2 prime smaller than datalen/ctxlen-1 (= 1498226207/512-1 = 2926222.06 in this case) = 2926181 in this case
 # use https://www.dcode.fr/prime-numbers-search

--- a/demo-training-run-v7-pile.sh
+++ b/demo-training-run-v7-pile.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#######################################################################################################################
+################################################################################
 #
 # Run demo-training-prepare.sh with the same MODEL_TYPE & N_LAYER & N_EMBD first
 # Or, rename your base model to rwkv-init.pth and put it in the output folder
@@ -7,7 +7,7 @@
 # The trainer will load the last rwkv-*.pth in the folder, such that it can continue from a stopped run
 # Therefore check the log (### Loading rwkv-xxx.pth... ###), and make sure you don't have extra rwkv-*.pth there
 #
-#######################################################################################################################
+################################################################################
 #
 MODEL_TYPE="x070" # x070 => rwkv-7.0
 #
@@ -17,7 +17,7 @@ N_EMBD="768"
 CTX_LEN="4096" # !!! change magic_prime if you change ctx_len !!!
 PROJ_DIR="out/L"$N_LAYER"-D"$N_EMBD"-"$MODEL_TYPE # set output folder
 #
-#######################################################################################################################
+################################################################################
 #
 M_BSZ="30" # for 80G VRAM GPUs
 LR_INIT="8e-4"
@@ -30,7 +30,7 @@ ADAM_EPS="1e-18"
 GRAD_CP=1 # 1 => slower, save VRAM; 0 => faster, more VRAM
 EPOCH_SAVE=50 # save every 50 "miniepochs" (1 miniepoch = 40320 * ctx_len tokens) => decrease if your GPU is weak
 #
-#######################################################################################################################
+################################################################################
 #
 N_NODE=1 # number of nodes
 GPU_PER_NODE=8 # number of GPUs per node

--- a/demo-training-run.sh
+++ b/demo-training-run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#######################################################################################################################
+################################################################################
 #
 # Run demo-training-prepare.sh with the same MODEL_TYPE & N_LAYER & N_EMBD first
 # Or, rename your base model to rwkv-init.pth and put it in the output folder
@@ -7,7 +7,7 @@
 # The trainer will load the last rwkv-*.pth in the folder, such that it can continue from a stopped run
 # Therefore check the log (### Loading rwkv-xxx.pth... ###), and make sure you don't have extra rwkv-*.pth there
 #
-#######################################################################################################################
+################################################################################
 #
 MODEL_TYPE="x070" # x060 => rwkv-6.0
 #
@@ -17,7 +17,7 @@ N_EMBD="768"
 CTX_LEN="512" # !!! change magic_prime if you change ctx_len !!!
 PROJ_DIR="out/L"$N_LAYER"-D"$N_EMBD"-"$MODEL_TYPE # set output folder
 #
-#######################################################################################################################
+################################################################################
 #
 # Note bsz & lr affects model & training performance
 # Small data => use smaller bsz & slightly smaller LR
@@ -31,7 +31,7 @@ LR_FINAL="6e-5"
 GRAD_CP=1 # 1 => slower, save VRAM; 0 => faster, more VRAM
 EPOCH_SAVE=10 # save every 10 "miniepochs" (1 miniepoch = 40320 * ctx_len tokens) => decrease if your GPU is weak
 #
-#######################################################################################################################
+################################################################################
 #
 # magic_prime = the largest 3n+2 prime smaller than datalen/ctxlen-1 (= 1498226207/512-1 = 2926222.06 in this case) = 2926181 in this case
 # use https://www.dcode.fr/prime-numbers-search

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -1,14 +1,9 @@
-########################################################################################################
+#################################################################
 # The RWKV Language Model - https://github.com/BlinkDL/RWKV-LM
-########################################################################################################
+#################################################################
 
-import json
 import math
-import os
-import random
-import sys
 
-import numpy as np
 import torch
 from pytorch_lightning.utilities import rank_zero_info
 from torch.utils.data import Dataset


### PR DESCRIPTION
For rwkv7, the dimension multiple of ffn has increased from 3.5 to 4, so the corresponding parameter args.dim_ffn needs to be modified as needed.
Fortunately, this parameter is no longer involved in rwkv block initialization (that is, rwkv7 default initialization is not affected by args.dim_ffn), but it will still be printed in the training log, which may cause new users to misestimate the model size, so it is better to modify it to the correct size.
![dim](https://github.com/user-attachments/assets/f86ff0d9-30ed-4ff6-a56a-1017c29e80e1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adjusted default configuration for model parameters to provide enhanced flexibility based on specific testing modes.

- **Bug Fixes**
  - Improved logic for setting model parameter defaults to ensure correct values are applied in all scenarios.

- **Chores**
  - Updated script formatting for improved readability by standardizing comment block styles.
  - Cleaned up unused imports and simplified header comments for better code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->